### PR TITLE
Require python3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 py_modules = onigurumacffi
 install_requires =
     cffi>=1
-python_requires = >=3.6
+python_requires = >=3.6.1
 setup_requires =
     cffi>=1
 


### PR DESCRIPTION
[python 3 statement - 3.6.0](https://github.com/asottile/scratch/wiki/python-3-statement#360)

(due to broken `NamedTuple` in 3.6.0)

Committed via https://github.com/asottile/all-repos