### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ resources:
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py36]
+    toxenvs: [py37]
     os: windows
     architectures: [x64, x86]
     wheel_tags: true
@@ -61,7 +61,7 @@ jobs:
       displayName: install oniguruma
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39]
+    toxenvs: [py37, py38, py39]
     os: linux
     additional_variables:
       ONIGURUMA_CLONE: $(Pipeline.Workspace)/oniguruma

--- a/bin/build-manylinux-wheels
+++ b/bin/build-manylinux-wheels
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import os
 import shutil
@@ -27,7 +29,7 @@ def main() -> int:
     else:
         img = 'onigurumacffi-build-cpython'
         base = 'quay.io/pypa/manylinux1_x86_64:latest'
-        py_bin = '/opt/python/cp36-cp36m/bin'
+        py_bin = '/opt/python/cp37-cp37m/bin'
 
     pkg = f'onigurumacffi=={args.version}'
 

--- a/onigurumacffi.py
+++ b/onigurumacffi.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import enum
 import re
 from typing import Any
-from typing import Optional
-from typing import Tuple
 
 import _onigurumacffi
 
@@ -48,8 +48,8 @@ class _Match:
     def __init__(
         self,
         s_b: bytes,
-        begs: Tuple[int, ...],
-        ends: Tuple[int, ...],
+        begs: tuple[int, ...],
+        ends: tuple[int, ...],
     ) -> None:
         self._s_b = s_b
         self._begs = begs
@@ -69,7 +69,7 @@ class _Match:
     def end(self, n: int = 0) -> int:
         return len(self._s_b[:self._ends[n]].decode())
 
-    def span(self, n: int = 0) -> Tuple[int, int]:
+    def span(self, n: int = 0) -> tuple[int, int]:
         return self.start(n), self.end(n)
 
     def expand(self, s: str) -> str:
@@ -80,7 +80,7 @@ class _Match:
         return self._s_b.decode()
 
 
-def _start_params(s: str, start: int) -> Tuple[bytes, int]:
+def _start_params(s: str, start: int) -> tuple[bytes, int]:
     return s.encode(), len(s[:start].encode())
 
 
@@ -88,7 +88,7 @@ def _region() -> Any:
     return _ffi.gc(_lib.onig_region_new(), _lib.onigcffi_region_free)
 
 
-def _match_ret(ret: int, s_b: bytes, region: Any) -> Optional[_Match]:
+def _match_ret(ret: int, s_b: bytes, region: Any) -> _Match | None:
     if ret == _lib.ONIG_MISMATCH:
         return None
     else:
@@ -116,7 +116,7 @@ class _Pattern:
             s: str,
             start: int = 0,
             flags: OnigSearchOption = OnigSearchOption.NONE,
-    ) -> Optional[_Match]:
+    ) -> _Match | None:
         s_b, start_b = _start_params(s, start)
         region = _region()
 
@@ -131,7 +131,7 @@ class _Pattern:
             s: str,
             start: int = 0,
             flags: OnigSearchOption = OnigSearchOption.NONE,
-    ) -> Optional[_Match]:
+    ) -> _Match | None:
         s_b, start_b = _start_params(s, start)
         region = _region()
 
@@ -143,7 +143,7 @@ class _Pattern:
 
 
 class _RegSet:
-    def __init__(self, patterns: Tuple[str, ...], regset_t: Any) -> None:
+    def __init__(self, patterns: tuple[str, ...], regset_t: Any) -> None:
         self._patterns = patterns
         self._regset_t = _ffi.gc(regset_t, _lib.onig_regset_free)
 
@@ -156,7 +156,7 @@ class _RegSet:
             s: str,
             start: int = 0,
             flags: OnigSearchOption = OnigSearchOption.NONE,
-    ) -> Tuple[int, Optional[_Match]]:
+    ) -> tuple[int, _Match | None]:
         s_b, start_b = _start_params(s, start)
         region = _ffi.new('OnigRegion*[1]')
 

--- a/onigurumacffi_build.py
+++ b/onigurumacffi_build.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = onigurumacffi
 install_requires =
     cffi>=1
-python_requires = >=3.6.1
+python_requires = >=3.7
 setup_requires =
     cffi>=1
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import sys
 

--- a/tests/onigurumacffi_test.py
+++ b/tests/onigurumacffi_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import onigurumacffi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos